### PR TITLE
Fix DropFrame

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -125,7 +125,7 @@ void increase_tc( cli_opt_t *opt, cli_timecode_t *timecode )
     }
 
     /* 29.97 and 59.94 Drop Frame - SMPTE 12M-2008 */
-    if( opt->drop_frame && !( timecode->min % 10 ) && timecode->sec == 0 && timecode->frame == 0 )
+    if( opt->drop_frame && ( ( timecode->min % 10 ) != 0 ) && timecode->sec == 0 && timecode->frame == 0 )
         timecode->frame = 2;
 
 }


### PR DESCRIPTION
This should not be a not. We should skip two timecode frames every minute except when on the 10's, not on the 10's
This was causing scc  caption insertion dropout's at 10 and 20 minutes when OBE-VOD would get stuck waiting for a 00:20:00;01 that never arrived.

The encode didn't stop to clarify, but the SCC inserter was forever stuck at 00:20:00;01while the changed code had pushed the timecode past to 00:20:00;02 and the encoder was now past the index that the inserter is looking for.